### PR TITLE
eliminate warning

### DIFF
--- a/nuts333.c
+++ b/nuts333.c
@@ -4827,7 +4827,10 @@ for(u=user_first;u!=NULL;u=u->next) {
 		}
 	if (people) {
 		if (u->afk) strcpy(idlestr," AFK");
-		else sprintf(idlestr,"%4d",idle);
+		else {
+			size_t result = snprintf(idlestr,sizeof(idlestr),"%4d",idle);
+			if (result>4) sprintf(idlestr,"%4d",9999);
+		}
 		if (u->type==REMOTE_TYPE) strcpy(sockstr," -");
 		else sprintf(sockstr,"%2d",u->socket);
 		sprintf(text,"%-15s :  %4s   %s    %s  %s %s %4d  %s  %s\n",u->name,level_name[u->level],sockstr,noyes1[u->ignall],noyes1[u->vis],idlestr,mins,portstr,u->site);


### PR DESCRIPTION
Eliminating this build warning:

`nuts333.c: In function ‘who’:
nuts333.c:4830:39: warning: ‘%4d’ directive writing between 4 and 9 bytes into a region of size 6 [-Wformat-overflow=]
 4830 |                 else sprintf(idlestr,"%4d",idle);
      |                                       ^~~
nuts333.c:4830:38: note: directive argument in the range [-35791394, 35791394]
 4830 |                 else sprintf(idlestr,"%4d",idle);
      |                                      ^~~~~
nuts333.c:4830:22: note: ‘sprintf’ output between 5 and 10 bytes into a destination of size 6
 4830 |                 else sprintf(idlestr,"%4d",idle);
      |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
`